### PR TITLE
Enable babel regenerator

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -16,7 +16,7 @@
       "@babel/plugin-transform-runtime",
       {
         "useESModules": true,
-        "regenerator": false
+        "regenerator": true
       }
     ]
   ],


### PR DESCRIPTION
Enable Babel regenerator to prevent intermittent loading failures in automated tests.

See: [MAT-4533](https://jira.cms.gov/browse/MAT-4533)
