### PR TITLE
Mat-4718: Add a cql library store to pass state to layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18019,7 +18019,8 @@
       }
     },
     "dset": {
-      "version": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
       "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
       "dev": true
     },
@@ -23501,7 +23502,7 @@
         "chalk": "^4.1.0",
         "clean-set": "^1.1.1",
         "color": "^3.1.3",
-        "dset": "^2.0.1",
+        "dset": "^3.1.2",
         "lodash.flatmap": "^4.5.0",
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",

--- a/src/Store/cqlLibraryStore.ts
+++ b/src/Store/cqlLibraryStore.ts
@@ -1,0 +1,20 @@
+import React from "react";
+import { BehaviorSubject } from "rxjs";
+import { CqlLibrary } from "@madie/madie-models";
+
+// immutable object that retains state, tracks updates
+const subject = new BehaviorSubject<CqlLibrary | null>(null);
+const initialState: null = null;
+let state: CqlLibrary | null = initialState;
+
+export const cqlLibraryStore = {
+  subscribe: (
+    setLibraryState: React.Dispatch<React.SetStateAction<CqlLibrary>>
+  ) => subject.subscribe((state) => setLibraryState(state)),
+  updateLibrary: (cqlLibrary: CqlLibrary | null) => {
+    state = Object.assign({}, cqlLibrary);
+    subject.next(state);
+  },
+  initialState,
+  state,
+};

--- a/src/madie-madie-util.tsx
+++ b/src/madie-madie-util.tsx
@@ -10,6 +10,7 @@ import { default as useKeyPress } from "./hooks/useKeyPress";
 import { default as useOktaTokens } from "./hooks/useOktaTokens";
 import { default as useOnClickOutside } from "./hooks/useOnClickOutside";
 import { measureStore } from "./Store/measureStore";
+import { cqlLibraryStore } from "./Store/cqlLibraryStore";
 import { routeHandlerStore } from "./Store/routeHandlerStore";
 import { default as useTerminologyServiceApi } from "./api/useTerminologyServiceApi";
 
@@ -19,6 +20,7 @@ export {
   useOktaTokens,
   useOnClickOutside,
   measureStore,
+  cqlLibraryStore,
   routeHandlerStore,
   useTerminologyServiceApi,
 };


### PR DESCRIPTION
This PR adds a separate store for storing information about a CQL library. This is required to give layout information about cql libraries being preserved in state in madie-cql-library