### PR TITLE
MAT-9187 Updating Service API calls to use a single ServiceConfig con…

### DIFF
--- a/src/Config/Config.test.ts
+++ b/src/Config/Config.test.ts
@@ -69,38 +69,25 @@ describe("getOktaConfig", () => {
       jest.clearAllMocks();
     });
 
-    it("should return valid ServiceConfig when all required fields are present", async () => {
-      const mockServiceConfig = {
-        measureService: {
-          baseUrl: "http://test.com",
-        },
-      };
-
+    it("should return ServiceConfig when response data object is present (even if minimal)", async () => {
+      const mockServiceConfig = { someField: { nested: true } } as any;
       mockedAxios.get.mockResolvedValueOnce({ data: mockServiceConfig });
-
       const result = await getServiceConfig();
-
       expect(mockedAxios.get).toHaveBeenCalledWith(
         "/env-config/serviceConfig.json"
       );
       expect(result).toEqual(mockServiceConfig);
     });
 
-    it("should throw error when measureService is missing", async () => {
-      const mockServiceConfig = {};
-      mockedAxios.get.mockResolvedValueOnce({ data: mockServiceConfig });
-
+    it("should throw error when response data is null/undefined", async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: null as any });
       await expect(getServiceConfig()).rejects.toThrow(
         "Invalid Service Config"
       );
     });
 
-    it("should throw error when measureService.baseUrl is missing", async () => {
-      const mockServiceConfig = {
-        measureService: {},
-      };
-      mockedAxios.get.mockResolvedValueOnce({ data: mockServiceConfig });
-
+    it("should throw error when axios request fails", async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error("network error"));
       await expect(getServiceConfig()).rejects.toThrow(
         "Invalid Service Config"
       );

--- a/src/Config/Config.test.ts
+++ b/src/Config/Config.test.ts
@@ -1,6 +1,5 @@
 import axios from "../api/axios-instance";
 import { getOktaConfig, getServiceConfig } from "./Config";
-import { OktaConfig } from "../api/ServiceContext";
 
 jest.mock("../api/axios-instance");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -70,7 +69,11 @@ describe("getOktaConfig", () => {
     });
 
     it("should return ServiceConfig when response data object is present (even if minimal)", async () => {
-      const mockServiceConfig = { someField: { nested: true } } as any;
+      const mockServiceConfig = {
+        measureService: {
+          baseUrl: "http://test.com",
+        },
+      };
       mockedAxios.get.mockResolvedValueOnce({ data: mockServiceConfig });
       const result = await getServiceConfig();
       expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -82,14 +85,14 @@ describe("getOktaConfig", () => {
     it("should throw error when response data is null/undefined", async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: null as any });
       await expect(getServiceConfig()).rejects.toThrow(
-        "Invalid Service Config"
+        "Failed to load service configuration"
       );
     });
 
     it("should throw error when axios request fails", async () => {
       mockedAxios.get.mockRejectedValueOnce(new Error("network error"));
       await expect(getServiceConfig()).rejects.toThrow(
-        "Invalid Service Config"
+        "Failed to load service configuration"
       );
     });
   });

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -10,16 +10,18 @@ interface OktaEnvConfig {
 }
 
 export async function getServiceConfig(): Promise<ServiceConfig> {
-  const serviceConfig: ServiceConfig = (
-    await axios.get<ServiceConfig>("/env-config/serviceConfig.json")
-  ).data;
-  if (
-    !(serviceConfig?.measureService && serviceConfig.measureService.baseUrl)
-  ) {
+  try {
+    const res = await axios.get<ServiceConfig>(
+      "/env-config/serviceConfig.json"
+    );
+    if (!res?.data) {
+      throw new Error("Service Config not found");
+    }
+    return res.data;
+  } catch (err) {
+    console.warn("An error occurred while loading the service config: ", err);
     throw new Error("Invalid Service Config");
   }
-
-  return serviceConfig;
 }
 
 export async function getOktaConfig(): Promise<OktaConfig> {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -14,13 +14,13 @@ export async function getServiceConfig(): Promise<ServiceConfig> {
     const res = await axios.get<ServiceConfig>(
       "/env-config/serviceConfig.json"
     );
-    if (!res?.data) {
-      throw new Error("Service Config not found");
+    if (!res || res.data == null) {
+      throw new Error("Failed to fetch valid service config");
     }
     return res.data;
   } catch (err) {
-    console.warn("An error occurred while loading the service config: ", err);
-    throw new Error("Invalid Service Config");
+    console.warn("Unexpected error loading service config", err);
+    throw new Error("Failed to load service configuration");
   }
 }
 

--- a/src/api/ServiceContext.tsx
+++ b/src/api/ServiceContext.tsx
@@ -44,7 +44,7 @@ export interface ServiceConfig {
   };
 }
 
-export const ServiceContext = createContext<ServiceConfig>(null);
+export const ServiceContext = createContext<ServiceConfig | null>(null);
 
 export const ApiContextProvider = ServiceContext.Provider;
 export const ApiContextConsumer = ServiceContext.Consumer;

--- a/src/api/useCqlLibraryServiceApi.test.ts
+++ b/src/api/useCqlLibraryServiceApi.test.ts
@@ -9,95 +9,350 @@ jest.mock("../hooks/useOktaTokens", () => () => ({
   getAccessToken: () => "mocked-token",
 }));
 
-jest.mock("./useServiceConfig", () => () => ({
-  cqlLibraryService: {
-    baseUrl: "http://localhost/api",
-  },
-}));
-
 describe("useCqlLibraryServiceApi", () => {
   const mockBaseUrl = "http://localhost/api";
   const mockToken = "mocked-token";
   const mockGetAccessToken = jest.fn().mockReturnValue(mockToken);
 
-  const cqlLibraryService = new CqlLibraryServiceApi(
+  const cqlLibraryServiceApi = new CqlLibraryServiceApi(
     mockBaseUrl,
     mockGetAccessToken
   );
 
+  beforeAll(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
-  describe("unlockLibraries", () => {
-    it("should unlock libraries successfully", async () => {
-      const expectedResponse = "Libraries unlocked";
-      mockedAxios.delete.mockResolvedValueOnce({ data: expectedResponse });
 
-      const result = await cqlLibraryService.unlockLibraries();
+  it("should create and return CqlLibraryServiceApi instance with correct config", () => {
+    expect(cqlLibraryServiceApi).toBeInstanceOf(CqlLibraryServiceApi);
+    expect(cqlLibraryServiceApi["baseUrl"]).toBe(mockBaseUrl);
+    expect(typeof cqlLibraryServiceApi["getAccessToken"]).toBe("function");
+  });
 
-      expect(mockedAxios.delete).toHaveBeenCalledWith(
-        `${mockBaseUrl}/libraries/unlock`,
-        {
-          headers: {
-            Authorization: `Bearer ${mockToken}`,
-          },
-        }
-      );
-      expect(result).toBe(expectedResponse);
-    });
+  it("should unlock libraries successfully", async () => {
+    const expectedResponse = "Libraries unlocked";
+    mockedAxios.delete.mockResolvedValueOnce({ data: expectedResponse });
 
-    it("should throw error when unlock fails", async () => {
-      const error = new Error("Failed to unlock libraries");
-      mockedAxios.delete.mockRejectedValueOnce(error);
+    const result = await cqlLibraryServiceApi.unlockLibraries();
 
-      await expect(cqlLibraryService.unlockLibraries()).rejects.toThrowError(
-        error.message
-      );
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/unlock`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockToken}`,
+        },
+      }
+    );
+    expect(result).toBe(expectedResponse);
+  });
 
-      expect(mockedAxios.delete).toHaveBeenCalledWith(
-        `${mockBaseUrl}/libraries/unlock`,
-        {
-          headers: {
-            Authorization: `Bearer ${mockToken}`,
-          },
-        }
-      );
-    });
+  it("should throw error when unlock fails", async () => {
+    const error = new Error("Failed to unlock libraries");
+    mockedAxios.delete.mockRejectedValueOnce(error);
 
-    describe("useCqlLibraryServiceApi function", () => {
-      it("should create and return CqlLibraryServiceApi instance with correct config", async () => {
-        const useCqlLibraryServiceApi = (
-          await import("./useCqlLibraryServiceApi")
-        ).default;
-        const api = await useCqlLibraryServiceApi();
+    await expect(cqlLibraryServiceApi.unlockLibraries()).rejects.toThrowError(
+      error.message
+    );
 
-        expect(api).toBeInstanceOf(CqlLibraryServiceApi);
-        expect(api).toEqual(
-          new CqlLibraryServiceApi("http://localhost/api", expect.any(Function))
-        );
-      });
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/unlock`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockToken}`,
+        },
+      }
+    );
+  });
 
-      it("should use correct baseUrl and getAccessToken from configs", async () => {
-        const useCqlLibraryServiceApi = (
-          await import("./useCqlLibraryServiceApi")
-        ).default;
-        const api = await useCqlLibraryServiceApi();
+  it("should fetch Cql Libraries", async () => {
+    const mockedResponse = { data: [{ id: "1" }] };
+    mockedAxios.put.mockResolvedValueOnce(mockedResponse);
+    const result = await cqlLibraryServiceApi.fetchCqlLibraries(
+      OwnershipType.OWNED,
+      25,
+      0,
+      {},
+      undefined,
+      undefined
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/searches`,
+      {},
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+        params: expect.objectContaining({
+          ownershipType: "OWNED",
+          limit: 25,
+          page: 0,
+        }),
+      })
+    );
+    expect(result).toEqual(mockedResponse.data);
+  });
 
-        // Test the api instance makes calls with correct config
-        const mockedResponse = "test response";
-        mockedAxios.delete.mockResolvedValueOnce({ data: mockedResponse });
+  it("should handle error in fetchCqlLibraries", async () => {
+    mockedAxios.put.mockRejectedValueOnce(new Error("canceled"));
+    await expect(
+      cqlLibraryServiceApi.fetchCqlLibraries(
+        OwnershipType.OWNED,
+        25,
+        0,
+        {},
+        undefined,
+        undefined
+      )
+    ).rejects.toThrow("canceled");
+  });
 
-        await api.unlockLibraries();
+  it("should fetch a single Cql Library", async () => {
+    const mockedResponse = { data: { id: "1" } };
+    mockedAxios.get.mockResolvedValueOnce(mockedResponse);
+    const result = await cqlLibraryServiceApi.fetchCqlLibrary("1");
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/1`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toEqual(mockedResponse.data);
+  });
 
-        expect(mockedAxios.delete).toHaveBeenCalledWith(
-          "http://localhost/api/libraries/unlock",
-          {
-            headers: {
-              Authorization: "Bearer mocked-token",
-            },
-          }
-        );
-      });
-    });
+  it("should handle error in fetchCqlLibrary", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("fail"));
+    await expect(cqlLibraryServiceApi.fetchCqlLibrary("1")).rejects.toThrow(
+      "Unable to fetch cql library"
+    );
+  });
+
+  it("should create a Cql Library", async () => {
+    mockedAxios.post.mockResolvedValueOnce({});
+    await cqlLibraryServiceApi.createCqlLibrary({ id: "1" } as any);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries`,
+      { id: "1" },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+  });
+
+  it("should update a Cql Library", async () => {
+    mockedAxios.put.mockResolvedValueOnce({ data: { id: "1" } });
+    await cqlLibraryServiceApi.updateCqlLibrary({ id: "1" } as any);
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/1`,
+      { id: "1" },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+  });
+
+  it("should create a version", async () => {
+    mockedAxios.put.mockResolvedValueOnce({ data: { id: "1" } });
+    await cqlLibraryServiceApi.createVersion("1", true);
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/version/1?isMajor=true`,
+      {},
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+  });
+
+  it("should create a draft", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { id: "1" } });
+    await cqlLibraryServiceApi.createDraft("1", "LibName", "QDM");
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/draft/1`,
+      { cqlLibraryName: "LibName", model: "QDM" },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+  });
+
+  it("should delete a draft", async () => {
+    mockedAxios.delete.mockResolvedValueOnce({ data: { id: "1" } });
+    await cqlLibraryServiceApi.deleteDraft("1");
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/1`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+  });
+
+  it("should fetch all owners", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ["owner1"] });
+    const ids = ["id1", "id2"];
+    const result = await cqlLibraryServiceApi.fetchAllOwners(ids);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/getAllOwners`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+        params: { librarySetIds: "id1,id2" },
+      })
+    );
+    expect(result).toEqual(["owner1"]);
+  });
+
+  it("should handle error in fetchAllOwners", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("fail"));
+    await expect(cqlLibraryServiceApi.fetchAllOwners(["id1"])).rejects.toThrow(
+      "Unable to fetch library owners"
+    );
+  });
+
+  it("should share libraries", async () => {
+    mockedAxios.put.mockResolvedValueOnce({ data: "shared" });
+    const map = new Map([["id1", ["user1"]]]);
+    const result = await cqlLibraryServiceApi.shareLibraries(map);
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/share`,
+      { id1: ["user1"] },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toBe("shared");
+  });
+
+  it("should handle error in shareLibraries", async () => {
+    mockedAxios.put.mockRejectedValueOnce(new Error("fail"));
+    const map = new Map([["id1", ["user1"]]]);
+    await expect(cqlLibraryServiceApi.shareLibraries(map)).rejects.toThrow();
+  });
+
+  it("should get shared libraries", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ["user1"] });
+    const ids = ["id1", "id2"];
+    const result = await cqlLibraryServiceApi.getSharedLibraries(ids);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/shared?libraryIds=${ids}`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toEqual(["user1"]);
+  });
+
+  it("should handle error in getSharedLibraries", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("fail"));
+    await expect(
+      cqlLibraryServiceApi.getSharedLibraries(["id1"])
+    ).rejects.toThrow();
+  });
+
+  it("should get recent libraries by librarySetId", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ["lib1"] });
+    const ids = ["id1", "id2"];
+    const result = await cqlLibraryServiceApi.getRecentLibrariesByLibrarySetId(
+      ids
+    );
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/recentsByLibrarySetId`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+        params: { librarySetIds: "id1,id2" },
+      })
+    );
+    expect(result).toEqual(["lib1"]);
+  });
+
+  it("should handle error in getRecentLibrariesByLibrarySetId", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("fail"));
+    await expect(
+      cqlLibraryServiceApi.getRecentLibrariesByLibrarySetId(["id1"])
+    ).rejects.toThrow();
+  });
+
+  it("should unshare libraries", async () => {
+    mockedAxios.put.mockResolvedValueOnce({ data: "unshared" });
+    const map = new Map([["id1", ["user1"]]]);
+    const result = await cqlLibraryServiceApi.unshareLibraries(map);
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/unshare`,
+      { id1: ["user1"] },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toBe("unshared");
+  });
+
+  it("should handle error in unshareLibraries", async () => {
+    mockedAxios.put.mockRejectedValueOnce(new Error("fail"));
+    const map = new Map([["id1", ["user1"]]]);
+    await expect(cqlLibraryServiceApi.unshareLibraries(map)).rejects.toThrow();
+  });
+
+  it("should get libraries by librarySetId", async () => {
+    mockedAxios.put.mockResolvedValueOnce({ data: ["lib1"] });
+    const result = await cqlLibraryServiceApi.getLibrariesByLibrarySetId(
+      "id1",
+      true,
+      { criteria: "test" }
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/byLibrarySetId`,
+      { criteria: "test" },
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+        params: { librarySetId: "id1", sortByLatestVersion: true },
+      })
+    );
+    expect(result).toEqual(["lib1"]);
+  });
+
+  it("should handle error in getLibrariesByLibrarySetId", async () => {
+    mockedAxios.put.mockRejectedValueOnce(new Error("fail"));
+    await expect(
+      cqlLibraryServiceApi.getLibrariesByLibrarySetId("id1", true, {
+        criteria: "test",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("should lock a library", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: "locked" });
+    const result = await cqlLibraryServiceApi.lockLibrary("lib1");
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${mockBaseUrl}/libraries/lib1/lock`,
+      null,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toBe("locked");
+  });
+
+  it("should handle error in lockLibrary", async () => {
+    mockedAxios.post.mockRejectedValueOnce("fail");
+    await expect(cqlLibraryServiceApi.lockLibrary("lib1")).rejects.toThrow();
+  });
+
+  it("should unlock a library", async () => {
+    mockedAxios.delete.mockResolvedValueOnce({ data: "unlocked" });
+    const result = await cqlLibraryServiceApi.unlockLibrary("lib1");
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      `${mockBaseUrl}/cql-libraries/lib1/unlock`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${mockToken}` },
+      })
+    );
+    expect(result).toBe("unlocked");
+  });
+
+  it("should handle error in unlockLibrary", async () => {
+    mockedAxios.delete.mockRejectedValueOnce("fail");
+    await expect(cqlLibraryServiceApi.unlockLibrary("lib1")).rejects.toThrow();
   });
 });

--- a/src/api/useCqlLibraryServiceApi.ts
+++ b/src/api/useCqlLibraryServiceApi.ts
@@ -282,7 +282,7 @@ export class CqlLibraryServiceApi {
   async unlockLibrary(libraryId: string): Promise<any> {
     try {
       const response = await axios.delete<String>(
-        `${this.baseUrl}/libraries/${libraryId}/unlock`,
+        `${this.baseUrl}/cql-libraries/${libraryId}/unlock`,
         {
           headers: {
             Authorization: `Bearer ${this.getAccessToken()}`,
@@ -298,7 +298,7 @@ export class CqlLibraryServiceApi {
   async unlockLibraries(): Promise<String> {
     try {
       const response = await axios.delete<String>(
-        `${this.baseUrl}/libraries/unlock`,
+        `${this.baseUrl}/cql-libraries/unlock`,
         {
           headers: {
             Authorization: `Bearer ${this.getAccessToken()}`,

--- a/src/api/useOrganizationApi.test.ts
+++ b/src/api/useOrganizationApi.test.ts
@@ -1,25 +1,8 @@
-import useOrganizationApi, {
-  OrganizationApi,
-  getServiceUrl,
-} from "./useOrganizationApi";
-import { ServiceConfig } from "../api/ServiceContext";
+import { OrganizationApi } from "./useOrganizationApi";
 import axios from "../api/axios-instance";
-import { waitFor } from "@testing-library/react";
 
 jest.mock("../api/axios-instance");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-
-const mockConfig: ServiceConfig = {
-  measureService: {
-    baseUrl: "url",
-  },
-  elmTranslationService: {
-    baseUrl: "",
-  },
-  terminologyService: {
-    baseUrl: "",
-  },
-};
 
 const organizations = [
   {
@@ -40,32 +23,19 @@ jest.mock("../hooks/useOktaTokens", () =>
   }))
 );
 
-jest.mock("../Config/Config", () => {
-  return {
-    getServiceConfig: jest.fn(() => Promise.resolve(mockConfig)),
-  };
-});
-
 describe("useOrganizationApi", () => {
+  let organizationApi: OrganizationApi;
+  beforeEach(() => {
+    const getAccessToken = jest.fn();
+    organizationApi = new OrganizationApi("test.url", getAccessToken);
+  });
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("should retrieve the service url", async () => {
-    const actual = await getServiceUrl();
-    expect(actual).toBe("url");
-  });
-
-  it("useOrganizationApi returns OrganizationApi", () => {
-    const actual: OrganizationApi = useOrganizationApi();
-    expect(actual).toBeTruthy();
   });
 
   it("returns an error when the organization list appears empty", () => {
     const resp = { status: 200, data: [] };
     mockedAxios.get.mockResolvedValue(resp);
-    expect.assertions(1);
-    const organizationApi: OrganizationApi = useOrganizationApi();
     organizationApi
       .getAllOrganizations()
       .then()
@@ -77,7 +47,6 @@ describe("useOrganizationApi", () => {
   it("retrieves the organization list", async () => {
     const resp = { status: 200, data: organizations };
     mockedAxios.get.mockResolvedValue(resp);
-    const organizationApi: OrganizationApi = useOrganizationApi();
     const orgList = await organizationApi.getAllOrganizations();
     expect(mockedAxios.get).toBeCalledTimes(1);
     expect(orgList).toEqual(organizations);

--- a/src/api/useOrganizationApi.ts
+++ b/src/api/useOrganizationApi.ts
@@ -1,18 +1,16 @@
 import axios from "../api/axios-instance";
-import { getServiceConfig } from "../Config/Config";
-import { ServiceConfig } from "./ServiceContext";
 import useOktaTokens from "../hooks/useOktaTokens";
 import { Organization } from "@madie/madie-models";
 import { wafIntercept } from "../madie-madie-util";
+import useServiceConfig from "./useServiceConfig";
 
 export class OrganizationApi {
-  constructor(private getAccessToken: () => string) {}
+  constructor(private baseUrl: string, private getAccessToken: () => string) {}
 
   async getAllOrganizations(): Promise<Organization[]> {
-    const baseUrl = await getServiceUrl();
     try {
       const response = await axios.get<Organization[]>(
-        `${baseUrl}/organizations`,
+        `${this.baseUrl}/organizations`,
         {
           headers: {
             Authorization: `Bearer ${this.getAccessToken()}`,
@@ -20,7 +18,7 @@ export class OrganizationApi {
         }
       );
       if (response?.data.length < 1) {
-        throw new Error("Empty list");
+        throw new Error("Organizations list is empty");
       }
       return response?.data;
     } catch (err) {
@@ -30,18 +28,13 @@ export class OrganizationApi {
   }
 }
 
-export const getServiceUrl = async () => {
-  const config: ServiceConfig = await getServiceConfig();
-  const serviceUrl: string = config?.measureService?.baseUrl;
-
-  return serviceUrl;
-};
-
 axios.interceptors.response.use((response) => {
   return response;
 }, wafIntercept);
 
 export default function useOrganizationApi(): OrganizationApi {
+  const { measureService } = useServiceConfig();
+  const { baseUrl } = measureService;
   const { getAccessToken } = useOktaTokens();
-  return new OrganizationApi(getAccessToken);
+  return new OrganizationApi(baseUrl, getAccessToken);
 }

--- a/src/api/useTerminologyServiceApi.test.ts
+++ b/src/api/useTerminologyServiceApi.test.ts
@@ -1,13 +1,10 @@
-import * as React from "react";
-import { waitFor } from "@testing-library/react";
 import useTerminologyServiceApi, {
   TerminologyServiceApi,
-  getServiceUrl,
 } from "./useTerminologyServiceApi";
-import { ServiceConfig } from "../api/ServiceContext";
+import { ServiceConfig } from "./ServiceContext";
 import axios from "../api/axios-instance";
 
-jest.mock("./axios-instance");
+jest.mock("../api/axios-instance");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const mockConfig: ServiceConfig = {
@@ -28,107 +25,110 @@ jest.mock("../hooks/useOktaTokens", () =>
   }))
 );
 
-jest.mock("../Config/Config", () => {
-  return {
-    getServiceConfig: jest.fn(() => Promise.resolve(mockConfig)),
-  };
-});
-
 describe("useTerminologyServiceApi", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should retrieve the service url", async () => {
-    const actual = await getServiceUrl();
-    expect(actual).toBe("url");
-  });
+  describe("TerminologyServiceApi", () => {
+    let api: TerminologyServiceApi;
+    const baseUrl = "url";
+    const getAccessToken = () => "test.jwt";
 
-  it("useTerminologyServiceApi returns TerminologyServiceApi", () => {
-    const actual: TerminologyServiceApi = useTerminologyServiceApi();
-    expect(actual).toBeTruthy();
-  });
+    beforeEach(() => {
+      api = new TerminologyServiceApi(baseUrl, getAccessToken);
+    });
 
-  it("checkLogin to UMLS success", async () => {
-    const resp = { status: 200, data: true };
-    mockedAxios.get.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    await terminlogyService.checkLogin();
-    expect(mockedAxios.get).toBeCalledTimes(1);
-  });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-  it("checkLogin to UMLS failure", async () => {
-    const resp = { status: 404, data: false, error: { message: "error" } };
-    mockedAxios.get.mockRejectedValueOnce(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    try {
-      const loggedIn = await terminlogyService.checkLogin();
-      expect(mockedAxios.get).toBeCalledTimes(1);
-      expect(loggedIn).toBeFalsy();
-    } catch {}
-  });
+    describe("checkLogin", () => {
+      it("returns true when status is 200", async () => {
+        mockedAxios.get.mockResolvedValueOnce({ status: 200 });
+        const result = await api.checkLogin();
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+          `${baseUrl}/vsac/umls-credentials/status`,
+          expect.objectContaining({
+            headers: {
+              Authorization: `Bearer ${getAccessToken()}`,
+              "Content-Type": "text/plain",
+            },
+            timeout: 15000,
+          })
+        );
+        expect(result).toBe(true);
+      });
 
-  it("checkLogin returns false if status is not 200", async () => {
-    const resp = { status: 201, data: true };
-    mockedAxios.get.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    const loggedIn = await terminlogyService.checkLogin();
-    expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(loggedIn).toBeFalsy();
-  });
+      it("throws error when axios fails", async () => {
+        mockedAxios.get.mockRejectedValueOnce(new Error("fail"));
+        await expect(api.checkLogin()).rejects.toThrow("fail");
+      });
 
-  it("Login to UMLS success", async () => {
-    const resp = { status: 200, data: "success" };
-    mockedAxios.post.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    await terminlogyService.loginUMLS("test");
-    expect(mockedAxios.post).toBeCalledTimes(1);
-  });
+      it("returns false when status is not 200", async () => {
+        mockedAxios.get.mockResolvedValueOnce({ status: 401 });
+        const result = await api.checkLogin();
+        expect(result).toBe(false);
+      });
+    });
 
-  it("Login to UMLS failure", async () => {
-    const resp = { status: 404, data: "failure", error: { message: "error" } };
-    mockedAxios.post.mockRejectedValueOnce(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    try {
-      await terminlogyService.loginUMLS("test");
-      expect(mockedAxios.post).toBeCalledTimes(1);
-    } catch {}
-  });
+    describe("loginUMLS", () => {
+      it("returns status and response when status is 200", async () => {
+        mockedAxios.post.mockResolvedValueOnce({ status: 200, data: "ok" });
+        const result = await api.loginUMLS("api-key");
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+          `${baseUrl}/vsac/umls-credentials`,
+          "api-key",
+          expect.objectContaining({
+            headers: {
+              Authorization: `Bearer ${getAccessToken()}`,
+              "Content-Type": "text/plain",
+            },
+            timeout: 15000,
+          })
+        );
+        expect(result).toBe("status: 200 response: ok");
+      });
 
-  it("Login to UMLS will not be successful unless status is 200", async () => {
-    const resp = { status: 201, data: "success" };
-    mockedAxios.post.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    const result = await terminlogyService.loginUMLS("test");
-    expect(mockedAxios.post).toBeCalledTimes(1);
-    expect(result).toContain("failure");
-  });
+      it("throws error when axios fails", async () => {
+        mockedAxios.post.mockRejectedValueOnce(new Error("fail"));
+        await expect(api.loginUMLS("api-key")).rejects.toThrow("fail");
+      });
 
-  it("Log out UMLS success", async () => {
-    const resp = { status: 200, data: true };
-    mockedAxios.delete.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    await terminlogyService.logoutUMLS();
-    expect(mockedAxios.delete).toBeCalledTimes(1);
-  });
+      it("returns 'failure' when status is not 200", async () => {
+        mockedAxios.post.mockResolvedValueOnce({ status: 401, data: "bad" });
+        const result = await api.loginUMLS("api-key");
+        expect(result).toBe("failure");
+      });
+    });
 
-  it("Log out UMLS failure", async () => {
-    const resp = { status: 404, data: false, error: { message: "error" } };
-    mockedAxios.delete.mockRejectedValueOnce(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    try {
-      const loggedout = await terminlogyService.logoutUMLS();
-      expect(mockedAxios.delete).toBeCalledTimes(1);
-      expect(loggedout).toBeFalsy();
-    } catch {}
-  });
+    describe("logoutUMLS", () => {
+      it("returns true when status is 200", async () => {
+        mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
+        const result = await api.logoutUMLS();
+        expect(mockedAxios.delete).toHaveBeenCalledWith(
+          `${baseUrl}/vsac/umls-credentials`,
+          expect.objectContaining({
+            headers: {
+              Authorization: `Bearer ${getAccessToken()}`,
+              "Content-Type": "text/plain",
+            },
+            timeout: 15000,
+          })
+        );
+        expect(result).toBe(true);
+      });
 
-  it("Log out UMLS returns false if status is not 200", async () => {
-    const resp = { status: 201, data: true };
-    mockedAxios.delete.mockResolvedValue(resp);
-    const terminlogyService: TerminologyServiceApi = useTerminologyServiceApi();
-    const loggedout = await terminlogyService.logoutUMLS();
-    expect(mockedAxios.delete).toBeCalledTimes(1);
-    expect(loggedout).toBeFalsy();
+      it("throws error when axios fails", async () => {
+        mockedAxios.delete.mockRejectedValueOnce(new Error("fail"));
+        await expect(api.logoutUMLS()).rejects.toThrow("fail");
+      });
+
+      it("returns false when status is not 200", async () => {
+        mockedAxios.delete.mockResolvedValueOnce({ status: 401 });
+        const result = await api.logoutUMLS();
+        expect(result).toBe(false);
+      });
+    });
   });
 });

--- a/src/api/useTerminologyServiceApi.ts
+++ b/src/api/useTerminologyServiceApi.ts
@@ -1,88 +1,75 @@
 import axios from "../api/axios-instance";
-import { getServiceConfig } from "../Config/Config";
-import { ServiceConfig } from "./ServiceContext";
 import useOktaTokens from "../hooks/useOktaTokens";
 import { wafIntercept } from "../madie-madie-util";
+import useServiceConfig from "./useServiceConfig";
 
 export class TerminologyServiceApi {
-  constructor(private getAccessToken: () => string) {}
+  constructor(private baseUrl: string, private getAccessToken: () => string) {}
 
   async checkLogin(): Promise<Boolean> {
-    const baseUrl = await getServiceUrl();
-    const resp = await axios
-      .get(`${baseUrl}/vsac/umls-credentials/status`, {
-        headers: {
-          Authorization: `Bearer ${this.getAccessToken()}`,
-          "Content-Type": "text/plain",
-        },
-        timeout: 15000,
-      })
-      .then((resp) => {
-        if (resp.status === 200) {
-          return true;
+    try {
+      const resp = await axios.get(
+        `${this.baseUrl}/vsac/umls-credentials/status`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.getAccessToken()}`,
+            "Content-Type": "text/plain",
+          },
+          timeout: 15000,
         }
-      })
-      .catch((error) => {
-        throw error;
-      });
-    return false;
+      );
+      return resp.status === 200;
+    } catch (error) {
+      throw error;
+    }
   }
 
   async loginUMLS(apiKey: string): Promise<String> {
-    const baseUrl = await getServiceUrl();
-    const resp = await axios
-      .post(`${baseUrl}/vsac/umls-credentials`, apiKey, {
-        headers: {
-          Authorization: `Bearer ${this.getAccessToken()}`,
-          "Content-Type": "text/plain",
-        },
-        timeout: 15000,
-      })
-      .then((resp) => {
-        if (resp.status === 200) {
-          return "status: " + resp.status + " response: " + resp.data;
+    try {
+      const resp = await axios.post(
+        `${this.baseUrl}/vsac/umls-credentials`,
+        apiKey,
+        {
+          headers: {
+            Authorization: `Bearer ${this.getAccessToken()}`,
+            "Content-Type": "text/plain",
+          },
+          timeout: 15000,
         }
-      })
-      .catch((error) => {
-        throw error;
-      });
-    return "failure";
+      );
+      if (resp.status === 200) {
+        return "status: " + resp.status + " response: " + resp.data;
+      }
+      return "failure";
+    } catch (error) {
+      throw error;
+    }
   }
 
   async logoutUMLS(): Promise<Boolean> {
-    const baseUrl = await getServiceUrl();
-    const resp = await axios
-      .delete(`${baseUrl}/vsac/umls-credentials`, {
+    try {
+      const resp = await axios.delete(`${this.baseUrl}/vsac/umls-credentials`, {
         headers: {
           Authorization: `Bearer ${this.getAccessToken()}`,
           "Content-Type": "text/plain",
         },
         timeout: 15000,
-      })
-      .then((resp) => {
-        // Check response status and return true if successful
-        return resp.status === 200;
-      })
-      .catch((error) => {
-        // Log the error or handle it as needed
-        console.error("UMLS Logout failed:", error);
-        throw error;
       });
-    return false;
+      return resp.status === 200;
+    } catch (error) {
+      console.error("UMLS Logout failed:", error);
+      throw error;
+    }
   }
 }
 
-export const getServiceUrl = async () => {
-  const config: ServiceConfig = await getServiceConfig();
-  const serviceUrl: string = config?.terminologyService?.baseUrl;
-
-  return serviceUrl;
-};
 axios.interceptors.response.use((response) => {
   return response;
 }, wafIntercept);
 
 export default function useTerminologyServiceApi(): TerminologyServiceApi {
+  const { terminologyService } = useServiceConfig();
+  const { baseUrl } = terminologyService;
   const { getAccessToken } = useOktaTokens();
-  return new TerminologyServiceApi(getAccessToken);
+  return new TerminologyServiceApi(baseUrl, getAccessToken);
 }

--- a/src/madie-madie-util.tsx
+++ b/src/madie-madie-util.tsx
@@ -6,7 +6,7 @@
     update types file with expected values in each app consuming
 */
 import useServiceConfig from "./api/useServiceConfig";
-import { getOktaConfig } from "./Config/Config";
+import { getOktaConfig, getServiceConfig } from "./Config/Config";
 import {
   ServiceContext,
   ApiContextConsumer,
@@ -35,6 +35,7 @@ import axios from "./api/axios-instance";
 
 export {
   useServiceConfig,
+  getServiceConfig,
   getOktaConfig,
   ServiceContext,
   useKeyPress,


### PR DESCRIPTION
…text which will be provided by corresponding singleSPA applications that uses these Services, this should limit the number of api calls to serviceConfig

## MADiE PR

Jira Ticket: [MAT-9187](https://jira.cms.gov/browse/MAT-9187)
(Optional) Related Tickets:

### Summary

1. Refactored code to use single source for ServiceConfig
2. Updated test suites to increase coverage

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
