### PR TITLE
MAT-9511: Transform Lock Exception to UI Exception for Group Delete API

### DIFF
--- a/src/api/useMeasureServiceApi.test.ts
+++ b/src/api/useMeasureServiceApi.test.ts
@@ -137,4 +137,19 @@ describe("MeasureServiceApi", () => {
     expect(consoleErrorMock).toHaveBeenCalled();
     consoleErrorMock.mockRestore();
   });
+
+  it("Should fail deleteGroup with 423 error", async () => {
+    mockedAxios.delete.mockClear();
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+    const errorMessage = "Group is locked for editing.";
+    mockedAxios.delete.mockRejectedValueOnce({
+      status: 423,
+      response: { data: { message: errorMessage } },
+    });
+    await expect(
+      measureServiceApi.deleteMeasureGroup(group.id, "measureId")
+    ).rejects.toThrow(errorMessage);
+    expect(consoleErrorMock).toHaveBeenCalled();
+    consoleErrorMock.mockRestore();
+  });
 });

--- a/src/api/useMeasureServiceApi.ts
+++ b/src/api/useMeasureServiceApi.ts
@@ -205,7 +205,9 @@ export class MeasureServiceApi {
     } catch (err) {
       const message = this.buildErrorMessage(
         err,
-        "Failed to delete the measure group."
+        err.status === 423
+          ? err?.response?.data?.message
+          : "Failed to delete the measure group."
       );
       console.error(message, err);
       throw new Error(message);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9511](https://jira.cms.gov/browse/MAT-9511)
(Optional) Related Tickets:

### Summary

Translate the API Lock Exception into UI Exception for Group delete API.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
