### PR TITLE
MAT-9815: centralize Transfer action and dialog in madie-util

### DIFF
--- a/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
+++ b/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
@@ -55,7 +55,7 @@ describe("TransferAction", () => {
     );
   });
 
-  it("Should enable action btn if user select one measure", async () => {
+  it("Should enable action btn if user select one measure", () => {
     render(
       <TransferAction
         measures={[mockMeasure]}
@@ -63,7 +63,7 @@ describe("TransferAction", () => {
         activeTab={0}
       />
     );
-    await expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+    expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
     expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
       "aria-label",
       TRANSFER

--- a/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
+++ b/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import TransferAction, {
+  NOTHING_SELECTED,
+  CANNOT_TRANSFER,
+  MORE_THAN_ONE_NOT_OWNED,
+  TRANSFER,
+} from "./TransferAction";
+import { Measure, MeasureSet, Model } from "@madie/madie-models";
+import { useUserRoles } from "../../../../hooks/useUserRoles";
+import checkUserCanEdit from "../../../../util/useCheckCanEdit";
+
+const mockUser = "test user";
+
+jest.mock("../../../../hooks/useUserRoles", () => ({
+  useUserRoles: jest.fn(() => ({
+    roles: [],
+    isAdmin: false,
+  })),
+}));
+
+jest.mock("../../../../util/useCheckCanEdit", () => ({
+  __esModule: true,
+  default: jest.fn(() => true),
+}));
+
+const mockMeasureSet = {
+  cmsId: "124",
+  measureSetId: "1-2-3-4",
+  owner: mockUser,
+} as unknown as MeasureSet;
+
+const mockMeasure = {
+  model: Model.QICORE,
+  measureSet: { ...mockMeasureSet, cmsId: null },
+  measureSetId: "1-2-3-4",
+  measureMetaData: { draft: true },
+} as unknown as Measure;
+
+describe("TransferAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUserRoles as jest.Mock).mockReturnValue({
+      roles: [],
+      isAdmin: false,
+    });
+  });
+
+  it("Should disable action btn if no measure selected", () => {
+    render(<TransferAction measures={[]} onClick={() => {}} activeTab={0} />);
+    expect(screen.getByTestId("transfer-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      NOTHING_SELECTED
+    );
+  });
+
+  it("Should enable action btn if user select one measure", () => {
+    render(
+      <TransferAction
+        measures={[mockMeasure]}
+        onClick={() => {}}
+        activeTab={0}
+      />
+    );
+    expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      TRANSFER
+    );
+  });
+
+  it("Should disable action btn if it's from Shared Measures tab", () => {
+    render(
+      <TransferAction
+        measures={[mockMeasure]}
+        onClick={() => {}}
+        activeTab={1}
+      />
+    );
+    expect(screen.getByTestId("transfer-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      CANNOT_TRANSFER
+    );
+  });
+
+  it("Should enable action btn if it's from All Measures tab and user is the owner", () => {
+    (checkUserCanEdit as jest.Mock).mockImplementationOnce(() => true);
+    render(
+      <TransferAction
+        measures={[mockMeasure]}
+        onClick={() => {}}
+        activeTab={2}
+      />
+    );
+    expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      TRANSFER
+    );
+  });
+
+  it("Should display nothing selected", () => {
+    (checkUserCanEdit as jest.Mock).mockImplementation(() => true);
+    render(<TransferAction measures={[]} onClick={() => {}} activeTab={2} />);
+    expect(screen.getByTestId("transfer-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      NOTHING_SELECTED
+    );
+  });
+
+  it("Should disable action btn if user is not the owner", () => {
+    (checkUserCanEdit as jest.Mock).mockImplementation(() => false);
+    const testMeasureSet = { ...mockMeasureSet, owner: "anotherUser" };
+    const testMeasure = { ...mockMeasure, measureSet: testMeasureSet };
+    render(
+      <TransferAction
+        measures={[testMeasure]}
+        onClick={() => {}}
+        activeTab={2}
+      />
+    );
+    expect(screen.getByTestId("transfer-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      MORE_THAN_ONE_NOT_OWNED
+    );
+  });
+
+  // Admin user tests
+  describe("Admin user transfer measure", () => {
+    beforeEach(() => {
+      (useUserRoles as jest.Mock).mockReturnValue({
+        roles: ["MADiE-Admin"],
+        isAdmin: true,
+      });
+    });
+
+    it("Should disable action btn if no measure selected even for admin", () => {
+      render(<TransferAction measures={[]} onClick={() => {}} activeTab={0} />);
+      expect(screen.getByTestId("transfer-action-btn")).toBeDisabled();
+      expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+        "aria-label",
+        NOTHING_SELECTED
+      );
+    });
+
+    it("Should enable action btn for admin on Owned Measures tab", () => {
+      render(
+        <TransferAction
+          measures={[mockMeasure]}
+          onClick={() => {}}
+          activeTab={0}
+        />
+      );
+      expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+      expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+        "aria-label",
+        TRANSFER
+      );
+    });
+
+    it("Should enable action btn for admin on Shared Measures tab", () => {
+      render(
+        <TransferAction
+          measures={[mockMeasure]}
+          onClick={() => {}}
+          activeTab={1}
+        />
+      );
+      expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+      expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+        "aria-label",
+        TRANSFER
+      );
+    });
+
+    it("Should enable action btn for admin on All Measures tab even for non-owned measures", () => {
+      (checkUserCanEdit as jest.Mock).mockImplementation(() => false);
+      const testMeasureSet = { ...mockMeasureSet, owner: "anotherUser" };
+      const testMeasure = { ...mockMeasure, measureSet: testMeasureSet };
+      render(
+        <TransferAction
+          measures={[testMeasure]}
+          onClick={() => {}}
+          activeTab={2}
+        />
+      );
+      expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+      expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
+        "aria-label",
+        TRANSFER
+      );
+    });
+  });
+});

--- a/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
+++ b/src/components/measureActions/actions/transferAction/TransferAction.test.tsx
@@ -55,7 +55,7 @@ describe("TransferAction", () => {
     );
   });
 
-  it("Should enable action btn if user select one measure", () => {
+  it("Should enable action btn if user select one measure", async () => {
     render(
       <TransferAction
         measures={[mockMeasure]}
@@ -63,7 +63,7 @@ describe("TransferAction", () => {
         activeTab={0}
       />
     );
-    expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
+    await expect(screen.getByTestId("transfer-action-btn")).not.toBeDisabled();
     expect(screen.getByTestId("transfer-action-tooltip")).toHaveAttribute(
       "aria-label",
       TRANSFER

--- a/src/components/measureActions/actions/transferAction/TransferAction.tsx
+++ b/src/components/measureActions/actions/transferAction/TransferAction.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState, useCallback } from "react";
+import { IconButton } from "@mui/material";
+import Tooltip from "@mui/material/Tooltip";
+import { Measure } from "@madie/madie-models";
+import SwapVertOutlinedIcon from "@mui/icons-material/SwapVertOutlined";
+import { useUserRoles } from "../../../../hooks/useUserRoles";
+import checkUserCanEdit from "../../../../util/useCheckCanEdit";
+
+interface PropTypes {
+  measures: Measure[];
+  onClick: () => void;
+  activeTab: number;
+}
+
+const isOwnerOfSelectedMeasure = (measures) => {
+  return (
+    measures &&
+    measures.every((measure) => {
+      return checkUserCanEdit(measure?.measureSet?.owner, []);
+    })
+  );
+};
+
+export const NOTHING_SELECTED = "Select a measure to transfer";
+export const CANNOT_TRANSFER = "You cannot transfer a measure you do not own";
+export const MORE_THAN_ONE_NOT_OWNED =
+  "You cannot transfer a measure you do not own, you have selected at least 1 measure that you do not own";
+export const TRANSFER = "Transfer";
+
+export default function TransferAction(props: PropTypes) {
+  const { measures, activeTab } = props;
+  const [disableTransferBtn, setDisableTransferBtn] = useState(true);
+  const [tooltipMessage, setTooltipMessage] = useState(NOTHING_SELECTED);
+  const userRoles = useUserRoles();
+
+  const validateTransferActionState = useCallback(() => {
+    setDisableTransferBtn(false);
+    setTooltipMessage(TRANSFER);
+
+    // If no measures selected, disable the button
+    if (measures?.length === 0) {
+      setDisableTransferBtn(true);
+      setTooltipMessage(NOTHING_SELECTED);
+      return;
+    }
+
+    // Admin users can transfer any measure
+    if (userRoles?.isAdmin) {
+      setDisableTransferBtn(false);
+      setTooltipMessage(TRANSFER);
+      return;
+    }
+
+    // Non-admin users: apply existing business rules
+    if (activeTab === 1) {
+      // Shared Measures tab - cannot transfer
+      setTooltipMessage(CANNOT_TRANSFER);
+      setDisableTransferBtn(true);
+    } else if (activeTab === 2) {
+      // All Measures tab - must be owner of all selected
+      if (!isOwnerOfSelectedMeasure(measures)) {
+        setTooltipMessage(MORE_THAN_ONE_NOT_OWNED);
+        setDisableTransferBtn(true);
+      }
+    }
+  }, [measures, activeTab, userRoles]);
+
+  useEffect(() => {
+    validateTransferActionState();
+  }, [measures, validateTransferActionState, activeTab]);
+
+  return (
+    <Tooltip
+      data-testid="transfer-action-tooltip"
+      title={tooltipMessage}
+      arrow
+      placement="top"
+      slotProps={{
+        tooltip: {
+          sx: {
+            zIndex: 99,
+            backgroundColor: "#333",
+            "& .MuiTooltip-arrow": {
+              color: "#333",
+            },
+          },
+        },
+      }}
+    >
+      <span>
+        <IconButton
+          onClick={props.onClick}
+          disabled={disableTransferBtn}
+          data-testid="transfer-action-btn"
+        >
+          <SwapVertOutlinedIcon style={{ transform: "rotate(90deg)" }} />
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/components/measureActions/dialogs/transferDialog/TransferDialog.scss
+++ b/src/components/measureActions/dialogs/transferDialog/TransferDialog.scss
@@ -1,0 +1,46 @@
+#transfer-measure {
+  margin: 36px 0 16px 0;
+  display: flex;
+  flex-direction: row;
+  column-gap: 24px;
+
+  > div {
+    flex-basis: 1;
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    max-width: 412px;
+  }
+}
+
+.transfer-dialog-info-text {
+  color: #515151;
+  font-weight: 400;
+  font-size: 16px;
+  font-family: Rubik, sans-serif;
+  padding-bottom: 17px;
+}
+
+.warning-message {
+  color: #d32f2f;
+  font-size: 14px;
+  font-family: Rubik, sans-serif;
+  font-weight: 400;
+}
+
+.owner {
+  color: #0073c8;
+  padding-top: 48px;
+  padding-bottom: -16px;
+  font-size: 16px;
+  font-family: Rubik, sans-serif;
+  font-weight: 500;
+}
+
+.current-owner {
+  padding-top: 5px;
+}
+
+.retainShareAccess {
+  padding-top: 20px;
+}

--- a/src/components/measureActions/dialogs/transferDialog/TransferDialog.test.tsx
+++ b/src/components/measureActions/dialogs/transferDialog/TransferDialog.test.tsx
@@ -1,0 +1,658 @@
+import * as React from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { within } from "@testing-library/dom";
+import { Measure, Model } from "@madie/madie-models";
+import TransferDialog, {
+  TRANSFER_MEASURE_SUCCESS,
+  TRANSFER_MEASURE_FAILURE,
+  INVALID_HARP_ID_MESSAGE,
+} from "./TransferDialog";
+import userEvent from "@testing-library/user-event";
+import { MeasureServiceApi } from "../../../../api/useMeasureServiceApi";
+
+jest.mock("../../../../api/useMeasureServiceApi", () => ({
+  __esModule: true,
+  default: jest.fn(() => mockMeasureServiceApi),
+}));
+
+const testUser = "test user";
+const mockMeasure1 = {
+  id: "TestMeasureId1",
+  measureName: "The Measure for Testing 1",
+  model: Model.QICORE,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+  measureSet: {
+    measureSetId: "MeasureSetId",
+    cmsId: 1,
+  },
+} as Measure;
+
+const mockMeasure2 = {
+  id: "TestMeasureId2",
+  measureName: "The Measure for Testing 2",
+  model: Model.QICORE_6_0_0,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+} as Measure;
+
+const mockMeasure3 = {
+  id: "TestMeasureId3",
+  measureName: "The Measure for Testing 3",
+  model: Model.QDM_5_6,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+} as Measure;
+
+const mockMeasure4 = {
+  id: "TestMeasureId4",
+  measureName: "The Measure for Testing 4",
+  model: Model.QICORE,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+} as Measure;
+
+const mockMeasure5 = {
+  id: "TestMeasureId5",
+  measureName: "The Measure for Testing 5",
+  model: Model.QICORE,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+} as Measure;
+
+const mockMeasure6 = {
+  id: "TestMeasureId6",
+  measureName: "The Measure for Testing 6",
+  model: Model.QDM_5_6,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+} as Measure;
+
+const mockTransferMeasuresResponse = jest.fn().mockResolvedValue({
+  status: 200,
+  data: [],
+});
+
+const mockMeasureServiceApi = {
+  transferMeasures: mockTransferMeasuresResponse,
+} as unknown as MeasureServiceApi;
+
+describe("Transfer Measures Dialog component", () => {
+  const { getByTestId, findByLabelText, findAllByText, getByRole } = screen;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const checkDataRows = async (number: number) => {
+    const tableBody = getByTestId("transfer-measure-tbl-body");
+    expect(tableBody).toBeInTheDocument();
+    const visibleRows = await within(tableBody).findAllByRole("row");
+    await waitFor(() => {
+      expect(visibleRows).toHaveLength(number);
+    });
+  };
+
+  it("should render transfer dialog", async () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(getByTestId("transfer-dialog")).toBeInTheDocument();
+    await checkDataRows(1);
+  });
+
+  it("should handle page change", async () => {
+    render(
+      <TransferDialog
+        measures={[
+          mockMeasure1,
+          mockMeasure2,
+          mockMeasure3,
+          mockMeasure4,
+          mockMeasure5,
+          mockMeasure6,
+        ]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(getByTestId("transfer-dialog")).toBeInTheDocument();
+
+    await checkDataRows(5);
+
+    const page2 = await findByLabelText("Go to page 2");
+    userEvent.click(page2);
+    // confirm there are 1 item on page
+    const tableBody = getByTestId("transfer-measure-tbl-body");
+    await waitFor(() => {
+      expect(tableBody?.querySelectorAll("tbody tr")).toHaveLength(1);
+    });
+  });
+
+  it("should handle limit change", async () => {
+    render(
+      <TransferDialog
+        measures={[
+          mockMeasure1,
+          mockMeasure2,
+          mockMeasure3,
+          mockMeasure4,
+          mockMeasure5,
+          mockMeasure6,
+        ]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+    expect(getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(getByTestId("transfer-dialog")).toBeInTheDocument();
+
+    // change limit
+    const [combobox] = await findAllByText("5");
+    userEvent.click(combobox);
+    const pageLimit10 = getByRole("option", {
+      name: /10/i,
+    });
+    userEvent.click(pageLimit10);
+    await checkDataRows(6);
+  });
+
+  it("should show success toast when transfer completes successfully", async () => {
+    const submitMock = jest.fn();
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={submitMock}
+        setStatusHandler={jest.fn()}
+      />
+    );
+    await checkDataRows(1);
+
+    const newHarpIdInput = getByTestId("harp-id-input");
+    expect(newHarpIdInput).toBeInTheDocument();
+    expect(newHarpIdInput.value).toBe("");
+    const transferBtn = getByTestId("transfer-save-button");
+    expect(transferBtn).toBeInTheDocument();
+    expect(transferBtn).toBeDisabled();
+
+    fireEvent.change(newHarpIdInput, {
+      target: { value: "newUser" },
+    });
+    expect(newHarpIdInput.value).toBe("newUser");
+    expect(transferBtn).toBeEnabled();
+
+    act(() => {
+      userEvent.click(transferBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockMeasureServiceApi.transferMeasures).toBeCalledWith(
+        [mockMeasure1.id],
+        "newUser",
+        false
+      );
+      expect(submitMock).toHaveBeenCalledWith({
+        toastType: "success",
+        toastMessage: TRANSFER_MEASURE_SUCCESS,
+        toastOpen: true,
+      });
+    });
+  });
+
+  it("should handle partial transfer (207)", async () => {
+    // Have 3 measures, fail 2 of them
+    const measures = [mockMeasure1, mockMeasure2, mockMeasure3];
+    const failedMeasureIds = [mockMeasure1.id, mockMeasure3.id];
+
+    // Mock API to return 207 with the 2 failed measure IDs
+    mockTransferMeasuresResponse.mockResolvedValue({
+      status: 207,
+      data: failedMeasureIds,
+    });
+
+    const setStatusHandlerMock = jest.fn();
+    const onCloseMock = jest.fn();
+
+    render(
+      <TransferDialog
+        measures={measures}
+        open={true}
+        onClose={onCloseMock}
+        setStatusHandler={setStatusHandlerMock}
+      />
+    );
+
+    const transferBtn = screen.getByTestId("transfer-save-button");
+    const newHarpIdInput = screen.getByTestId("harp-id-input");
+
+    expect(transferBtn).toBeInTheDocument();
+    expect(transferBtn).toBeDisabled();
+
+    fireEvent.change(newHarpIdInput, { target: { value: "newUser" } });
+
+    expect(transferBtn).toBeEnabled();
+
+    fireEvent.click(transferBtn);
+
+    await waitFor(() => {
+      // Verify API call
+      expect(mockTransferMeasuresResponse).toHaveBeenCalledWith(
+        measures.map((m) => m.id),
+        "newUser",
+        false
+      );
+
+      // Verify warning status with 2 failed measures
+      expect(setStatusHandlerMock).toHaveBeenCalledWith({
+        warning: {
+          status: true,
+          primaryMessage: `2 Measures could not be transferred. Please try again, or contact help desk if the issue persists.`,
+          secondaryMessages: expect.arrayContaining([
+            mockMeasure1.measureName,
+            mockMeasure3.measureName,
+          ]),
+        },
+      });
+
+      // Verify dialog closes without toast
+      expect(onCloseMock).toHaveBeenCalledWith({
+        toastType: "success",
+        toastOpen: false,
+      });
+    });
+  });
+
+  it("should show generic failure toast when API call fails", async () => {
+    mockMeasureServiceApi.transferMeasures = jest
+      .fn()
+      .mockRejectedValue(new Error(TRANSFER_MEASURE_FAILURE));
+
+    const submitMock = jest.fn();
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={submitMock}
+        setStatusHandler={jest.fn()}
+      />
+    );
+    await checkDataRows(1);
+
+    const newHarpIdInput = getByTestId("harp-id-input");
+    expect(newHarpIdInput).toBeInTheDocument();
+    expect(newHarpIdInput.value).toBe("");
+    const transferBtn = getByTestId("transfer-save-button");
+    expect(transferBtn).toBeInTheDocument();
+    expect(transferBtn).toBeDisabled();
+
+    fireEvent.change(newHarpIdInput, {
+      target: { value: "newUser" },
+    });
+    expect(newHarpIdInput.value).toBe("newUser");
+    expect(transferBtn).toBeEnabled();
+
+    act(() => {
+      userEvent.click(transferBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockMeasureServiceApi.transferMeasures).toBeCalledWith(
+        [mockMeasure1.id],
+        "newUser",
+        false
+      );
+      expect(submitMock).toHaveBeenCalledWith({
+        toastType: "danger",
+        toastMessage: TRANSFER_MEASURE_FAILURE,
+        toastOpen: true,
+      });
+    });
+  });
+
+  it("should display field-level error and not close dialog when API returns 400 with invalid HARP ID message", async () => {
+    mockMeasureServiceApi.transferMeasures = jest.fn().mockRejectedValue({
+      response: {
+        status: 400,
+        data: { message: INVALID_HARP_ID_MESSAGE },
+      },
+    });
+
+    const onCloseMock = jest.fn();
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={onCloseMock}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    const newHarpIdInput = getByTestId("harp-id-input");
+    const transferBtn = getByTestId("transfer-save-button");
+
+    fireEvent.change(newHarpIdInput, { target: { value: "invalidUser" } });
+
+    act(() => {
+      userEvent.click(transferBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(INVALID_HARP_ID_MESSAGE)).toBeInTheDocument();
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should show generic failure toast when API returns 400 with a different message", async () => {
+    mockMeasureServiceApi.transferMeasures = jest.fn().mockRejectedValue({
+      response: {
+        status: 400,
+        data: { message: "Some other 400 error" },
+      },
+    });
+
+    const onCloseMock = jest.fn();
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={onCloseMock}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    const newHarpIdInput = getByTestId("harp-id-input");
+    const transferBtn = getByTestId("transfer-save-button");
+
+    fireEvent.change(newHarpIdInput, { target: { value: "someUser" } });
+
+    act(() => {
+      userEvent.click(transferBtn);
+    });
+
+    await waitFor(() => {
+      expect(onCloseMock).toHaveBeenCalledWith({
+        toastType: "danger",
+        toastMessage: TRANSFER_MEASURE_FAILURE,
+        toastOpen: true,
+      });
+      expect(
+        screen.queryByText(INVALID_HARP_ID_MESSAGE)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should display measure count in info text", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1, mockMeasure2, mockMeasure3]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /You are about to Transfer ownership of the 3 selected measure/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should display 'This action cannot be undone!' warning for regular users", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/This action cannot be undone/)
+    ).toBeInTheDocument();
+  });
+
+  it("should NOT display 'This action cannot be undone!' warning for admin transfers", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+        isAdminTransfer={true}
+      />
+    );
+
+    expect(
+      screen.queryByText(/This action cannot be undone/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("should display updated info text with correct wording", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /All versions and drafts will be transferred, but only the most recent measure name appears in the list below/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should NOT display owner column in measures table for regular transfers", () => {
+    const measureWithOwner = {
+      ...mockMeasure1,
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "testOwner",
+      },
+    };
+
+    render(
+      <TransferDialog
+        measures={[measureWithOwner]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    // The table should NOT have "Current Measure Owner" as a column header
+    const tableHeaders = screen.getAllByRole("columnheader");
+    const ownerColumnHeader = tableHeaders.find(
+      (header) => header.textContent === "Current Measure Owner"
+    );
+    expect(ownerColumnHeader).toBeUndefined();
+  });
+
+  it("should display owner column in measures table for admin transfers", () => {
+    const measureWithOwner = {
+      ...mockMeasure1,
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "testOwner",
+      },
+    };
+
+    render(
+      <TransferDialog
+        measures={[measureWithOwner]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+        isAdminTransfer={true}
+      />
+    );
+
+    // The "Current Measure Owner" should be a table header
+    const tableHeaders = screen.getAllByRole("columnheader");
+    const ownerColumnHeader = tableHeaders.find(
+      (header) => header.textContent === "Current Measure Owner"
+    );
+    expect(ownerColumnHeader).toBeDefined();
+
+    // And the owner value should be displayed in the table
+    expect(screen.getByText("testOwner")).toBeInTheDocument();
+  });
+
+  it("should NOT display 'Current Measure Owner' form field for admin transfers", () => {
+    const measureWithOwner = {
+      ...mockMeasure1,
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "testOwner",
+      },
+    };
+
+    render(
+      <TransferDialog
+        measures={[measureWithOwner]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+        isAdminTransfer={true}
+      />
+    );
+
+    // The "Current Measure Owner" form field should NOT exist
+    expect(screen.queryByTestId("current-owner")).not.toBeInTheDocument();
+  });
+
+  it("should display formatted owner name in Current Measure Owner field for non-admin transfers", async () => {
+    const measureWithOwner = {
+      ...mockMeasure1,
+      ownerDisplayName: "John Doe",
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "john_doe",
+      },
+    };
+
+    render(
+      <TransferDialog
+        measures={[measureWithOwner]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText("John Doe (john_doe)")).toBeInTheDocument();
+  });
+
+  it("should fall back to harpId in Current Measure Owner field when ownerDisplayName is missing", async () => {
+    const measureWithOwner = {
+      ...mockMeasure1,
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "john_doe",
+      },
+    };
+
+    render(
+      <TransferDialog
+        measures={[measureWithOwner]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText("john_doe")).toBeInTheDocument();
+  });
+
+  it("should display green Transfer button for admin transfers", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+        isAdminTransfer={true}
+      />
+    );
+
+    const transferButton = screen.getByTestId("transfer-save-button");
+    expect(transferButton).toBeInTheDocument();
+    expect(transferButton).toHaveClass("qpp-c-button--cyan");
+  });
+
+  it("should display red Transfer button for regular transfers", () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+        isAdminTransfer={false}
+      />
+    );
+
+    const transferButton = screen.getByTestId("transfer-save-button");
+    expect(transferButton).toBeInTheDocument();
+    expect(transferButton).toHaveClass("qpp-c-button--danger-primary");
+  });
+
+  it("should keep Transfer button disabled until New Measure Owner field has text", async () => {
+    render(
+      <TransferDialog
+        measures={[mockMeasure1]}
+        open={true}
+        onClose={jest.fn()}
+        setStatusHandler={jest.fn()}
+      />
+    );
+
+    const transferButton = screen.getByTestId("transfer-save-button");
+    const harpIdInput = screen.getByTestId("harp-id-input");
+
+    // Button should be disabled initially
+    expect(transferButton).toBeDisabled();
+
+    // Enter text in New Measure Owner field
+    fireEvent.change(harpIdInput, {
+      target: { value: "newOwner" },
+    });
+
+    // Button should now be enabled
+    await waitFor(() => {
+      expect(transferButton).toBeEnabled();
+    });
+
+    // Clear the field
+    fireEvent.change(harpIdInput, {
+      target: { value: "" },
+    });
+
+    // Button should be disabled again
+    await waitFor(() => {
+      expect(transferButton).toBeDisabled();
+    });
+  });
+});

--- a/src/components/measureActions/dialogs/transferDialog/TransferDialog.tsx
+++ b/src/components/measureActions/dialogs/transferDialog/TransferDialog.tsx
@@ -1,0 +1,227 @@
+import React, { useRef, useEffect } from "react";
+import {
+  MadieDialog,
+  TextField,
+  ReadOnlyTextField,
+  FormControlLabel,
+} from "@madie/madie-design-system/dist/react";
+import { Measure } from "@madie/madie-models";
+import { useFormik } from "formik";
+import { Checkbox, Divider } from "@mui/material";
+import "./TransferDialog.scss";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import * as Yup from "yup";
+import useMeasureServiceApi from "../../../../api/useMeasureServiceApi";
+import TransferredMeasuresTable from "./TransferredMeasuresTable";
+import { formatOwner } from "./ownerFormatter";
+
+// Resets the parent status banner. Mirrors the shape of the measure
+// workspace's INITIAL_STATUS_HANDLER so the callback contract is unchanged.
+const INITIAL_STATUS_HANDLER = {
+  success: { status: undefined, primaryMessage: "", secondaryMessages: [] },
+  warning: { status: false, primaryMessage: "", secondaryMessages: [] },
+  error: false,
+  errorMessage: "",
+  outboundAnnotations: [],
+  hasSubtitle: false,
+};
+
+export const TRANSFER_MEASURE_SUCCESS =
+  "The measure(s) were successfully transferred. If you chose to retain share access, you will still be able to edit the measures.";
+export const TRANSFER_MEASURE_FAILURE =
+  "Unable to transfer the selected measure(s) to the harpId. If the error persists, please contact the help desk.";
+export const INVALID_HARP_ID_MESSAGE =
+  "The provided HARP ID is not associated with an active MADiE user.";
+
+interface TransferDialogProps {
+  measures: Measure[];
+  open: boolean;
+  onClose: Function;
+  setStatusHandler: Function;
+  isAdminTransfer?: boolean;
+}
+
+const TransferDialog = ({
+  measures,
+  open,
+  onClose,
+  setStatusHandler,
+  isAdminTransfer = false,
+}: TransferDialogProps) => {
+  const measureServiceApi = useRef(useMeasureServiceApi()).current;
+
+  const handleSave = async () => {
+    setStatusHandler(INITIAL_STATUS_HANDLER);
+
+    const measureIds = measures.map((m) => m.id);
+
+    const transferPromise = measureServiceApi.transferMeasures(
+      measureIds,
+      formik.values.harpId,
+      formik.values.retainShareAccess
+    );
+
+    return transferPromise
+      .then((response) => {
+        if (response.status === 200) {
+          onClose({
+            toastType: "success",
+            toastMessage: TRANSFER_MEASURE_SUCCESS,
+            toastOpen: true,
+          });
+        } else if (response.status === 207) {
+          const failedMeasureIds: string[] = response.data;
+
+          const failedMeasureNames = measures
+            .filter((measure) => failedMeasureIds.includes(measure.id))
+            .map((measure) => measure.measureName);
+
+          setStatusHandler({
+            warning: {
+              status: true,
+              primaryMessage: `${failedMeasureNames?.length} Measures could not be transferred. Please try again, or contact help desk if the issue persists.`,
+              secondaryMessages: failedMeasureNames,
+            },
+          });
+
+          // Close dialog and refresh the measure list without showing a toast.
+          onClose({
+            toastType: "success",
+            toastOpen: false,
+          });
+        }
+      })
+      .catch((error) => {
+        console.error("TransferDialog: handleSave: error = ", error);
+        if (
+          error?.response?.status === 400 &&
+          error?.response?.data?.message === INVALID_HARP_ID_MESSAGE
+        ) {
+          formik.setFieldError("harpId", INVALID_HARP_ID_MESSAGE);
+        } else {
+          onClose({
+            toastType: "danger",
+            toastMessage: TRANSFER_MEASURE_FAILURE,
+            toastOpen: true,
+          });
+        }
+      });
+  };
+
+  const formik = useFormik({
+    initialValues: {
+      currentUser: formatOwner(
+        measures?.[0]?.ownerDisplayName,
+        measures?.[0]?.measureSet?.owner
+      ),
+      harpId: "",
+      retainShareAccess: false,
+    },
+    enableReinitialize: true,
+    validationSchema: Yup.object().shape({
+      harpId: Yup.string().required("New Measure Owner is required."),
+    }),
+    onSubmit: handleSave,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      formik.resetForm();
+    }
+  }, [open]);
+
+  return (
+    <>
+      <MadieDialog
+        form
+        title="Transfer Measure Ownership"
+        dialogProps={{
+          onClose,
+          open,
+          onSubmit: formik.handleSubmit,
+          maxWidth: "lg",
+          "data-testid": "transfer-dialog",
+        }}
+        cancelButtonProps={{
+          variant: "outline",
+          cancelText: "Cancel",
+          "data-testid": "transfer-cancel-button",
+        }}
+        continueButtonProps={{
+          variant: isAdminTransfer ? "cyan-primary" : "danger-primary",
+          type: "submit",
+          continueText: "Transfer",
+          "data-testid": "transfer-save-button",
+          disabled: !formik.dirty || !formik.values.harpId,
+        }}
+      >
+        <div className="transfer-dialog-info-text">
+          <div>
+            You are about to Transfer ownership of the {measures?.length || 0}{" "}
+            selected measure(s) below. All versions and drafts will be
+            transferred, but only the most recent measure name appears in the
+            list below.
+          </div>
+          {!isAdminTransfer && (
+            <div className="warning-message">
+              <ErrorOutlineIcon color="error" fontSize="small" />
+              This action cannot be undone.
+            </div>
+          )}
+        </div>
+        <div data-testid="transferred-measures-list">
+          <TransferredMeasuresTable
+            measures={measures}
+            showOwnerColumn={isAdminTransfer}
+          />
+        </div>
+        <div className="owner">Owner</div>
+        <Divider sx={{ borderColor: "#8c8c8c", paddingBottom: "16px" }} />
+
+        <div id="transfer-measure">
+          {!isAdminTransfer && (
+            <div className="current-owner">
+              <ReadOnlyTextField
+                label="Current Measure Owner"
+                inputProps={{
+                  "data-testid": "current-owner",
+                }}
+                size="large"
+                {...formik.getFieldProps("currentUser")}
+              />
+            </div>
+          )}
+          <div>
+            <TextField
+              label="New Measure Owner"
+              id="harp-id-input"
+              required={true}
+              inputProps={{
+                "data-testid": "harp-id-input",
+              }}
+              error={formik.touched.harpId && Boolean(formik.errors.harpId)}
+              helperText={formik.touched.harpId && formik.errors.harpId}
+              {...formik.getFieldProps("harpId")}
+            />
+          </div>
+          <div className="retainShareAccess">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  {...formik.getFieldProps("retainShareAccess")}
+                  checked={formik.values.retainShareAccess}
+                  name="retainShareAccess"
+                  id="retainShareAccess"
+                  data-testid="retainShareAccess"
+                />
+              }
+              label="Retain Share Access after Transfer"
+            />
+          </div>
+        </div>
+      </MadieDialog>
+    </>
+  );
+};
+
+export default TransferDialog;

--- a/src/components/measureActions/dialogs/transferDialog/TransferredMeasuresTable.test.tsx
+++ b/src/components/measureActions/dialogs/transferDialog/TransferredMeasuresTable.test.tsx
@@ -1,0 +1,232 @@
+import * as React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Measure, Model } from "@madie/madie-models";
+import TransferredMeasuresTable from "./TransferredMeasuresTable";
+
+const testUser = "test user";
+const mockMeasure1 = {
+  id: "TestMeasureId1",
+  measureName: "The Measure for Testing 1",
+  model: Model.QICORE,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+  measureSet: {
+    measureSetId: "MeasureSetId",
+    cmsId: 1,
+    owner: "owner1",
+  },
+} as Measure;
+
+const mockMeasure2 = {
+  id: "TestMeasureId2",
+  measureName: "The Measure for Testing 2",
+  model: Model.QICORE_6_0_0,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId",
+  measureSet: {
+    measureSetId: "MeasureSetId",
+    cmsId: 2,
+    owner: "owner2",
+  },
+} as Measure;
+
+const mockMeasure3 = {
+  id: "TestMeasureId3",
+  measureName: "The Measure for Testing 3",
+  model: Model.QDM_5_6,
+  createdBy: testUser,
+  measureSetId: "MeasureSetId3",
+  measureSet: {
+    measureSetId: "MeasureSetId3",
+    owner: "owner3",
+  },
+} as Measure;
+
+describe("TransferredMeasuresTable component", () => {
+  it("should render table with measures without owner column", () => {
+    render(
+      <TransferredMeasuresTable
+        measures={[mockMeasure1, mockMeasure2]}
+        showOwnerColumn={false}
+      />
+    );
+
+    expect(screen.getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(screen.getByText("Measure")).toBeInTheDocument();
+    expect(screen.getByText("Model")).toBeInTheDocument();
+    expect(screen.getByText("CMS ID")).toBeInTheDocument();
+    expect(screen.queryByText("Current Measure Owner")).not.toBeInTheDocument();
+
+    expect(screen.getByText("The Measure for Testing 1")).toBeInTheDocument();
+    expect(screen.getByText("The Measure for Testing 2")).toBeInTheDocument();
+  });
+
+  it("should render table with measures with owner column", () => {
+    render(
+      <TransferredMeasuresTable
+        measures={[mockMeasure1, mockMeasure2]}
+        showOwnerColumn={true}
+      />
+    );
+
+    expect(screen.getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(screen.getByText("Measure")).toBeInTheDocument();
+    expect(screen.getByText("Model")).toBeInTheDocument();
+    expect(screen.getByText("CMS ID")).toBeInTheDocument();
+    expect(screen.getByText("Current Measure Owner")).toBeInTheDocument();
+
+    expect(screen.getByText("owner1")).toBeInTheDocument();
+    expect(screen.getByText("owner2")).toBeInTheDocument();
+  });
+
+  it("should display formatted owner name in owner column for admin transfers", () => {
+    const measureWithDisplayName = {
+      ...mockMeasure1,
+      ownerDisplayName: "John Doe",
+      measureSet: {
+        ...mockMeasure1.measureSet,
+        owner: "john_doe",
+      },
+    };
+
+    render(
+      <TransferredMeasuresTable
+        measures={[measureWithDisplayName]}
+        showOwnerColumn={true}
+      />
+    );
+
+    expect(screen.getByText("John Doe (john_doe)")).toBeInTheDocument();
+  });
+
+  it("should display CMS ID with FHIR suffix for QI-Core measures", () => {
+    render(
+      <TransferredMeasuresTable
+        measures={[mockMeasure1]}
+        showOwnerColumn={false}
+      />
+    );
+
+    expect(screen.getByText("0001FHIR")).toBeInTheDocument();
+  });
+
+  it("should display CMS ID without FHIR suffix for QDM measures", () => {
+    render(
+      <TransferredMeasuresTable
+        measures={[mockMeasure3]}
+        showOwnerColumn={false}
+      />
+    );
+
+    // QDM measure has no CMS ID, so it should display empty
+    const rows = screen.getAllByTestId(/^row-/);
+    expect(rows.length).toBe(1);
+  });
+
+  it("should render pagination controls", () => {
+    const measures = [];
+    for (let i = 0; i < 10; i++) {
+      measures.push({
+        ...mockMeasure1,
+        id: `id${i}`,
+        measureName: `Measure ${i}`,
+      });
+    }
+
+    render(
+      <TransferredMeasuresTable measures={measures} showOwnerColumn={false} />
+    );
+
+    expect(
+      screen.getByTestId("trasfer-measure-pagination")
+    ).toBeInTheDocument();
+  });
+
+  it("should paginate measures correctly", async () => {
+    const measures = [];
+    for (let i = 0; i < 10; i++) {
+      measures.push({
+        ...mockMeasure1,
+        id: `id${i}`,
+        measureName: `Measure ${i}`,
+      });
+    }
+
+    render(
+      <TransferredMeasuresTable measures={measures} showOwnerColumn={false} />
+    );
+
+    // Should show first 5 measures by default
+    expect(screen.getByText("Measure 0")).toBeInTheDocument();
+    expect(screen.getByText("Measure 4")).toBeInTheDocument();
+    expect(screen.queryByText("Measure 5")).not.toBeInTheDocument();
+
+    // Navigate to page 2
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Measure 0")).not.toBeInTheDocument();
+      expect(screen.getByText("Measure 5")).toBeInTheDocument();
+      expect(screen.getByText("Measure 9")).toBeInTheDocument();
+    });
+  });
+
+  it("should change page limit", async () => {
+    const measures = [];
+    for (let i = 0; i < 15; i++) {
+      measures.push({
+        ...mockMeasure1,
+        id: `id${i}`,
+        measureName: `Measure ${i}`,
+      });
+    }
+
+    render(
+      <TransferredMeasuresTable measures={measures} showOwnerColumn={false} />
+    );
+
+    // Default limit is 5
+    expect(screen.getByText("Measure 0")).toBeInTheDocument();
+    expect(screen.queryByText("Measure 5")).not.toBeInTheDocument();
+
+    // Change limit to 10
+    const limitSelect = screen.getByRole("combobox");
+    fireEvent.mouseDown(limitSelect);
+
+    await waitFor(() => {
+      const option10 = screen.getByRole("option", { name: "10" });
+      fireEvent.click(option10);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Measure 0")).toBeInTheDocument();
+      expect(screen.getByText("Measure 9")).toBeInTheDocument();
+      expect(screen.queryByText("Measure 10")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should handle empty measures array", () => {
+    render(<TransferredMeasuresTable measures={[]} showOwnerColumn={false} />);
+
+    expect(screen.getByTestId("transfer-measure-tbl")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("trasfer-measure-pagination")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show all measures when count is less than limit", () => {
+    render(
+      <TransferredMeasuresTable
+        measures={[mockMeasure1, mockMeasure2]}
+        showOwnerColumn={false}
+      />
+    );
+
+    expect(screen.getByText("The Measure for Testing 1")).toBeInTheDocument();
+    expect(screen.getByText("The Measure for Testing 2")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("trasfer-measure-pagination")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/measureActions/dialogs/transferDialog/TransferredMeasuresTable.tsx
+++ b/src/components/measureActions/dialogs/transferDialog/TransferredMeasuresTable.tsx
@@ -1,0 +1,210 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  ColumnDef,
+  flexRender,
+} from "@tanstack/react-table";
+import {
+  Pagination,
+  TruncateText,
+} from "@madie/madie-design-system/dist/react";
+import tw from "twin.macro";
+import "styled-components/macro";
+import { Measure } from "@madie/madie-models";
+import { formatCmsId } from "../../../../util/cmsIdFormatter";
+import { formatOwner } from "./ownerFormatter";
+
+const TH = tw.th`p-3 text-left text-sm`;
+const TD = tw.td`p-3 text-left text-sm break-keep`;
+
+interface TransferredMeasuresTableProps {
+  measures: Measure[];
+  showOwnerColumn?: boolean;
+}
+
+interface RowData {
+  measureName: string;
+  model: string;
+  cmsId: number;
+  owner?: string;
+}
+
+export const TransferredMeasuresTable = ({
+  measures,
+  showOwnerColumn = false,
+}: TransferredMeasuresTableProps) => {
+  const [visibleMeasures, setVisibleMeasures] = useState<Measure[]>([]);
+  // pagination utilities
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalItems, setTotalItems] = useState<number>(0);
+  const [visibleItems, setVisibleItems] = useState<number>(0);
+  const [offset, setOffset] = useState<number>(0);
+  const [currentLimit, setCurrentLimit] = useState<number>(5);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const managePagination = useCallback(() => {
+    if (measures.length < currentLimit) {
+      setOffset(0);
+      setVisibleMeasures([...measures]);
+      setVisibleItems(measures.length);
+      setTotalItems(measures.length);
+      setTotalPages(1);
+    } else {
+      const start = (currentPage - 1) * currentLimit;
+      const end = start + currentLimit;
+      const newVisibleMeasures = measures.slice(start, end);
+      setVisibleMeasures(newVisibleMeasures);
+      setOffset(start);
+      setVisibleItems(newVisibleMeasures.length);
+      setTotalItems(measures.length);
+      setTotalPages(Math.ceil(measures.length / currentLimit));
+    }
+  }, [
+    currentLimit,
+    currentPage,
+    measures,
+    setOffset,
+    setVisibleMeasures,
+    setVisibleItems,
+    setTotalItems,
+    setTotalPages,
+  ]);
+
+  const canGoNext = (() => {
+    return currentPage < totalPages;
+  })();
+  const canGoPrev = currentPage > 1;
+
+  const handlePageChange = (e, v) => {
+    setCurrentPage(v);
+  };
+  const handleLimitChange = (e) => {
+    setCurrentLimit(e.target.value);
+    setCurrentPage(1);
+  };
+
+  useEffect(() => {
+    managePagination();
+  }, [measures, currentPage, currentLimit, managePagination]);
+
+  // Table data
+  const data: RowData[] = useMemo(
+    () =>
+      visibleMeasures.map((measure) => ({
+        measureName: measure.measureName,
+        model: measure.model,
+        cmsId: measure.measureSet?.cmsId,
+        owner: formatOwner(measure.ownerDisplayName, measure.measureSet?.owner),
+      })),
+    [visibleMeasures]
+  );
+
+  // Column definitions
+  const columns: ColumnDef<RowData>[] = useMemo(() => {
+    const baseColumns: ColumnDef<RowData>[] = [
+      {
+        accessorKey: "measureName",
+        header: "Measure",
+        cell: (info) => (
+          <TruncateText
+            text={info.row.original.measureName}
+            maxLength={120}
+            dataTestId={`measure-name-${info.row.original.measureName}`}
+          />
+        ),
+      },
+      {
+        accessorKey: "model",
+        header: "Model",
+        cell: (info) => info.getValue(),
+      },
+      {
+        accessorKey: "cmsId",
+        header: "CMS ID",
+        cell: (info) =>
+          formatCmsId(info.getValue() as number, info.row.original.model),
+      },
+    ];
+
+    if (showOwnerColumn) {
+      baseColumns.push({
+        accessorKey: "owner",
+        header: "Current Measure Owner",
+        cell: (info) => info.getValue() || "",
+      });
+    }
+
+    return baseColumns;
+  }, [showOwnerColumn]);
+
+  // Create the table instance
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <>
+      <table tw="min-w-full" data-testid="transfer-measure-tbl">
+        <thead tw="bg-slate">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TH key={header.id} scope="col">
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </TH>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody data-testid="transfer-measure-tbl-body">
+          {table.getRowModel().rows.map((row, index) => (
+            <tr
+              key={row.id}
+              className="transfer-measure-row"
+              data-testid={`row-${index}`}
+              style={{
+                borderTop: "solid 1px #8c8c8c",
+                paddingTop: "32px",
+              }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TD key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TD>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {measures?.length > 0 && (
+        <div
+          className="pagination-container"
+          data-testid="trasfer-measure-pagination"
+        >
+          <Pagination
+            totalItems={totalItems}
+            limitOptions={[5, 10, 25, 50]}
+            visibleItems={visibleItems}
+            offset={offset}
+            handlePageChange={handlePageChange}
+            handleLimitChange={handleLimitChange}
+            page={currentPage}
+            limit={currentLimit}
+            count={totalPages}
+            hideNextButton={!canGoNext}
+            hidePrevButton={!canGoPrev}
+            shape="rounded"
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TransferredMeasuresTable;

--- a/src/components/measureActions/dialogs/transferDialog/ownerFormatter.ts
+++ b/src/components/measureActions/dialogs/transferDialog/ownerFormatter.ts
@@ -1,0 +1,9 @@
+export function formatOwner(
+  displayName: string | undefined,
+  harpId: string | undefined
+): string {
+  if (!harpId) return "-";
+  if (!displayName || displayName === "-" || displayName === harpId)
+    return harpId;
+  return `${displayName} (${harpId})`;
+}

--- a/src/components/measureActions/index.ts
+++ b/src/components/measureActions/index.ts
@@ -19,3 +19,5 @@ export {
 } from "./exportUtil";
 export { default as ShareAction } from "./actions/shareAction/ShareAction";
 export { default as ShareDialog } from "./dialogs/shareDialog/ShareDialog";
+export { default as TransferAction } from "./actions/transferAction/TransferAction";
+export { default as TransferDialog } from "./dialogs/transferDialog/TransferDialog";

--- a/src/madie-madie-util.tsx
+++ b/src/madie-madie-util.tsx
@@ -59,6 +59,8 @@ import {
   EXPORT_FAILURE_MESSAGE,
   ShareAction,
   ShareDialog,
+  TransferAction,
+  TransferDialog,
 } from "./components/measureActions";
 
 export {
@@ -114,4 +116,6 @@ export {
   EXPORT_FAILURE_MESSAGE,
   ShareAction,
   ShareDialog,
+  TransferAction,
+  TransferDialog,
 };


### PR DESCRIPTION
## MADiE PR

Move TransferAction, TransferDialog, and TransferredMeasuresTable (with their tests) into components/measureActions so they can be shared by madie-measure and madie-admin.

Jira Ticket: [MAT-9815](https://jira.cms.gov/browse/MAT-9815)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
