### PR TITLE
MAT-9814: fix Shared Measures unshare targeting wrong user

### DIFF
--- a/src/components/measureActions/dialogs/shareDialog/ShareDialog.test.tsx
+++ b/src/components/measureActions/dialogs/shareDialog/ShareDialog.test.tsx
@@ -1544,8 +1544,48 @@ describe("UnshareFromMe Confirmation Dialog component", () => {
       />
     );
 
-    expect(screen.getByTestId("share-confirmation-dialog")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("share-confirmation-dialog")
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("share-dialog")).toBeNull();
+  });
+
+  it("should unshare the passed unshareFromUser (not the logged-in user) and show the measure name", async () => {
+    const mockOnSave = jest.fn();
+    mockMeasureServiceApi.unshareMeasures = mockUnshareMeasures;
+    render(
+      <ShareDialog
+        measures={[mockMeasure1, mockMeasure2]}
+        open={true}
+        option="UnshareFromMe"
+        onClose={jest.fn()}
+        onSave={mockOnSave}
+        unshareFromUser="userId1"
+      />
+    );
+
+    const dialog = await screen.findByTestId("share-confirmation-dialog");
+    expect(dialog).toHaveTextContent(mockMeasure1.measureName);
+    expect(dialog).toHaveTextContent(mockMeasure2.measureName);
+
+    // The target user is the passed profile user, not the logged-in "test user".
+    expect(dialog).toHaveTextContent("userId1");
+    expect(dialog).not.toHaveTextContent("test user");
+
+    await userEvent.click(
+      await screen.findByTestId("share-confirmation-dialog-accept-button")
+    );
+
+    await waitFor(() => {
+      expect(mockUnshareMeasures).toHaveBeenCalledWith(expect.any(Map));
+    });
+    const requestMap = mockUnshareMeasures.mock.calls[0][0] as Map<
+      string,
+      string[]
+    >;
+
+    expect(requestMap.get(mockMeasure1.id)).toEqual(["userId1"]);
+    expect(requestMap.get(mockMeasure2.id)).toEqual(["userId1"]);
   });
 
   it("should close Share dialog and call onClose when option is 'Share With'", async () => {
@@ -1607,7 +1647,9 @@ describe("UnshareFromMe Confirmation Dialog component", () => {
       />
     );
 
-    expect(screen.getByTestId("share-confirmation-dialog")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("share-confirmation-dialog")
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("share-dialog")).toBeNull();
 
     const cancelButton = screen.getByTestId(

--- a/src/components/measureActions/dialogs/shareDialog/ShareDialog.tsx
+++ b/src/components/measureActions/dialogs/shareDialog/ShareDialog.tsx
@@ -55,6 +55,10 @@ interface ShareDialogProps {
   onClose: Function;
   onSave: Function;
   isAdmin?: boolean;
+  // HARP id to unshare from on the "UnshareFromMe" path. Defaults to the
+  // logged-in user in the Measures workspace while the Admin User Profile passes the
+  // profile user being viewed.
+  unshareFromUser?: string;
 }
 
 interface SharedMeasure {
@@ -116,9 +120,13 @@ const ShareDialog = ({
   onClose,
   onSave,
   isAdmin,
+  unshareFromUser,
 }: ShareDialogProps) => {
   const { getUserName } = useOktaTokens();
   const userName = getUserName();
+  // User whose access is removed on the "UnshareFromMe" path: the profile user
+  // in the Admin User Profile or defaults to the logged-in user if no unshareFromUser provided.
+  const unshareTargetUser = unshareFromUser ?? userName;
 
   const showShareDialog = option === "Share With" || option === "Unshare";
 
@@ -626,19 +634,19 @@ const ShareDialog = ({
   }, [rowSelection]);
 
   useEffect(() => {
-    // Only trigger when dialog is open and the option is UnshareFromMe
-    if (option === "UnshareFromMe" && open) {
-      // Prepare the unshare request
+    // Only trigger once the dialog is open, the option is UnshareFromMe, and the
+    // shared measures have loaded.
+    if (option === "UnshareFromMe" && open && sharedMeasures.length) {
       const directUnshareRequest = new Map<string, string[]>();
-      measures.forEach((measure) => {
-        directUnshareRequest.set(measure.id, [userName]);
+      sharedMeasures.forEach((sharedMeasure) => {
+        directUnshareRequest.set(sharedMeasure.measureId, [unshareTargetUser]);
       });
       setUnshareMeasuresRequest(directUnshareRequest);
 
       // Open the confirmation dialog
       setConfirmationDialogOpen(true);
     }
-  }, [option, open, measures, userName]);
+  }, [option, open, sharedMeasures, unshareTargetUser]);
 
   // export user list in Excel format for admin users
   const handleExportUserList = async (e) => {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9814](https://jira.cms.gov/browse/MAT-9814)
(Optional) Related Tickets:
https://github.com/MeasureAuthoringTool/madie-admin/pull/55

### Summary

On the Admin Shared Measures tab, when performing an Unshare action, fixed issue where the confirmation modal listed the logged-in admin instead of the profile user the measure is shared with.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
